### PR TITLE
Clean up entity metadata after use

### DIFF
--- a/obsidiandestroyer/src/main/java/com/drtshock/obsidiandestroyer/managers/ChunkManager.java
+++ b/obsidiandestroyer/src/main/java/com/drtshock/obsidiandestroyer/managers/ChunkManager.java
@@ -404,6 +404,10 @@ public class ChunkManager {
         // Call the new explosion event
         ObsidianDestroyer.getInstance().getServer().getPluginManager().callEvent(explosionEvent);
 
+        if (detonator != null) {
+            // Remove metadata since it is no longer needed
+            detonator.removeMetadata("ObbyEntity", ObsidianDestroyer.getInstance());
+        }
         // ==========================
         // Ignore if event is cancelled and not bypassed.
         if (explosionEvent.isCancelled()) {


### PR DESCRIPTION
Currently Bukkit's entity metadata store does not remove metadata from entities that are no longer in the world, which causes an accumulation of useless metadata.

Over a long uptime or after excessive use of TNT, the accumulated metadata size dominates the server's available memory, requiring a restart.

This change will remove the metadata from entities immediately after use.